### PR TITLE
Remove rapidlinkr link

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,6 @@
 
 					<section data-state="links" data-markdown>
 						<script type="text/template">
-							[http://www.rapidlinkr.com/]  
 							https://openseadragon.github.io/  
 							http://www.jacklmoore.com/zoom/  
 							http://www.archive.org/stream/birdbookillustra00reedrich  


### PR DESCRIPTION
It was really just to have access to during the presentation.
